### PR TITLE
refactor(dependencies): change `@kaiu/serializer` state to peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
 
 install:
   - npm install
-  - npm install @kaiu/serializer
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 
 install:
   - npm install
+  - npm install @kaiu/serializer
 
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Angular wrapper for [@kaiu/serializer](https://www.npmjs.com/package/@kaiu/seria
 
 Install through npm:
 ```
-npm install --save @kaiu/ng-serializer
+npm install --save @kaiu/ng-serializer @kaiu/serializer
 ```
 
 Then include in your apps module:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@angular/platform-server": "4.1.0",
     "@types/jasmine": "2.6.0",
     "@types/node": "8.0.1",
-    "@kaiu/serializer": "^1.1.0",
+    "@kaiu/serializer": "1.1.0",
     "chalk": "1.1.3",
     "codecov": "2.1.0",
     "codelyzer": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@kaiu/serializer": "^1.0.1"
   },
   "peerDependencies": {
     "@angular/common": ">= 4.1.0",
-    "@angular/core": ">= 4.1.0"
+    "@angular/core": ">= 4.1.0",
+    "@kaiu/serializer": "^1.0.3"
   },
   "devDependencies": {
     "@angular/animations": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@angular/common": ">= 4.1.0",
     "@angular/core": ">= 4.1.0",
-    "@kaiu/serializer": "^1.0.3"
+    "@kaiu/serializer": "^1.1.0"
   },
   "devDependencies": {
     "@angular/animations": "4.1.0",
@@ -51,6 +51,7 @@
     "@angular/platform-server": "4.1.0",
     "@types/jasmine": "2.6.0",
     "@types/node": "8.0.1",
+    "@kaiu/serializer": "^1.1.0",
     "chalk": "1.1.3",
     "codecov": "2.1.0",
     "codelyzer": "3.1.1",


### PR DESCRIPTION
The goal is to be able to update serializer without having to release a new version of ng-serializer each time, while nothgin changed in it.

It's also better for IDE completion, as `@kaiu/serializer` will be included in package.json, it'll be used for automatic import resolution.